### PR TITLE
Update nRF52832 #define to match BSP

### DIFF
--- a/examples/dotstar_wing/dotstar_wing.ino
+++ b/examples/dotstar_wing/dotstar_wing.ino
@@ -13,7 +13,7 @@
 #elif defined(__AVR_ATmega328P__)
   #define DATAPIN    2
   #define CLOCKPIN   4
-#elif defined(ARDUINO_FEATHER52832)
+#elif defined(ARDUINO_NRF52832_FEATHER)
   #define DATAPIN    7
   #define CLOCKPIN   16
 #elif defined(TEENSYDUINO)


### PR DESCRIPTION
The `dotstar_wing` example is currently broken for the [nRF52832](https://www.adafruit.com/product/3406) since `ARDUINO_FEATHER52832` is never defined in the current BSP and it thus falls through to the `#else` which contains the wrong pin values.  Updating the `#elif` to use `ARDUINO_NRF52832_FEATHER` accurately reflects the current BSP, resulting in the correct pins being used, and the example being fixed! :bowtie: :rotating_light: :sparkles: 