### PR TITLE
REQ: Please Add Support for the MRK-RGB Shield and the Portenta_H7.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 Adafruit_GFX-compatible library for DotStar matrices and grids. Controls single and tiled DotStar matrices or grids assembled from DotStar LED strip. Requires Adafruit_DotStar and Adafruit_GFX libraries.
 
 After downloading, rename folder to 'Adafruit_DotStarMatrix' and install in Arduino Libraries folder. Restart Arduino IDE, then open File->Sketchbook->Library->Adafruit_DotStarMatrix->matrixtest sketch.
+
+Update:  This has been updated to work with the MKR-RGB Shield and the Portanta_H7.  A jumper must be placed from A3->A5.

--- a/examples/dotstar_wing/dotstar_wing.ino
+++ b/examples/dotstar_wing/dotstar_wing.ino
@@ -56,11 +56,19 @@
 //   DOTSTAR_GBR  Pixels are wired for GBR bitstream (some older DotStars)
 //   DOTSTAR_BGR  Pixels are wired for BGR bitstream (APA102-2020 DotStars)
 
+#ifndef PORTENTA_H7
 Adafruit_DotStarMatrix matrix = Adafruit_DotStarMatrix(
-                                  12, 7, DATAPIN, CLOCKPIN,		// MKR-RGB Shield
+                                  12, 6, DATAPIN, CLOCKPIN,		
                                   DS_MATRIX_BOTTOM     + DS_MATRIX_LEFT +
                                   DS_MATRIX_ROWS + DS_MATRIX_PROGRESSIVE,
-                                  DOTSTAR_BGR);
+				  DOTSTAR_BGR);
+#else
+Adafruit_DotStarMatrix matrix = Adafruit_DotStarMatrix(
+				 12, 7, DATAPIN, CLOCKPIN,		// MKR-RGB Shield
+				 DS_MATRIX_BOTTOM     + DS_MATRIX_LEFT +
+				 DS_MATRIX_ROWS + DS_MATRIX_PROGRESSIVE,
+				 DOTSTAR_BGR);
+#endif
 
 const uint16_t primaryColors[] = {
   matrix.Color(255, 0, 0), matrix.Color(0, 255, 0), matrix.Color(0, 0, 255)
@@ -85,14 +93,15 @@ char adafruit[] = "portentah7";
 #endif
 
 void setup() {
+#ifdef  PORTENTA_H7	
 	unsigned int counter_main = 0;
-	
+#endif	
 	Serial.begin(115200);
-	
+#ifdef  PORTENTA_H7		
   do {
 	  counter_main++;
   } while ( !Serial && ( counter_main < SERIAL_COUNTER_TIME_OUT) );
-  
+#endif  
   // uncomment to have wait
   //while (!Serial) delay(500); 
 #ifndef  PORTENTA_H7

--- a/examples/dotstar_wing/dotstar_wing.ino
+++ b/examples/dotstar_wing/dotstar_wing.ino
@@ -25,6 +25,11 @@
 #elif defined(ESP32)
   #define DATAPIN    27
   #define CLOCKPIN   13
+#elif defined(PORTENTA_H7)
+  #define DATAPIN    A5	   // jumper must be placed from A3->A5
+  #define CLOCKPIN   A4
+  #define SERIAL_COUNTER_TIME_OUT 5000    // so serial port doesn't hang the board
+  #define SERIAL_CTR_TIME_OUT 5
 #else // // 32u4, M0, M4, nrf52840 and 328p
   #define DATAPIN    11
   #define CLOCKPIN   13
@@ -52,7 +57,7 @@
 //   DOTSTAR_BGR  Pixels are wired for BGR bitstream (APA102-2020 DotStars)
 
 Adafruit_DotStarMatrix matrix = Adafruit_DotStarMatrix(
-                                  12, 6, DATAPIN, CLOCKPIN,
+                                  12, 7, DATAPIN, CLOCKPIN,		// MKR-RGB Shield
                                   DS_MATRIX_BOTTOM     + DS_MATRIX_LEFT +
                                   DS_MATRIX_ROWS + DS_MATRIX_PROGRESSIVE,
                                   DOTSTAR_BGR);
@@ -73,15 +78,32 @@ const uint16_t adaColors[] = {
   matrix.Color(255, 220, 0)  //! orange/yellow
 };
 
+#ifndef  PORTENTA_H7
 char adafruit[] = "ADAFRUIT!";
+#else
+char adafruit[] = "portentah7";
+#endif
 
 void setup() {
-  Serial.begin(115200);
- 
+	unsigned int counter_main = 0;
+	
+	Serial.begin(115200);
+	
+  do {
+	  counter_main++;
+  } while ( !Serial && ( counter_main < SERIAL_COUNTER_TIME_OUT) );
+  
   // uncomment to have wait
   //while (!Serial) delay(500); 
-
+#ifndef  PORTENTA_H7
   Serial.println("\nDotstar Matrix Wing");
+#else
+  pinMode(A4, OUTPUT);
+  pinMode(A5, OUTPUT);  
+  delay(2500);
+  Serial.println("\nMKR-RGB on H7");
+#endif
+  
   matrix.begin();
   matrix.setFont(&TomThumb);
   matrix.setTextWrap(false);


### PR DESCRIPTION
Note - example in DotStarMatrix will demonstrate the changes - so, this in addition to the PR in the DotStar PR are necessary.

REQ: Please Add Support for the MRK-RGB Shield and the Portenta_H7. A jumper must be placed from A3->A5 when using the MRK-RGB shield on the Portenta H7.

List of changes:
The MRK-RGB shield has to used in 'bit-bang' mode to work on the Portenta H7 and one jumper must be added - the
A3 pin must be jumpered to A5. It's a relatively easy change to be able to use the shield on the H7. Yes, it's a one-off but
I must admit I like to use that shield on the H7. And, you can't have too many graphics libs, right?

In Adafruit_Dotstar lib:
In Adafruit_Dotstar.h:
added:
#define PORTENTA_H7 // STM32H747xI
In Adafruit_Dotstar.cpp:
added:
#ifndef PORTENTA_H7 'wrapper' to force use of software spi (a.k.a. bit-bang mode).

..\examples\dotstar_wing\dotstar_wing.ino updated to add MRK-RGB shield capability.
Note, if preferred, a new .ino can be made - we can call it mrk-rgb-shield.ino or something else
more appropriate.
dotstar_wing.ino has been updated with the appropriate #ifdef PORTENTA_H7 wrappers to run the code.

Readme.md:
Updated to summarize changes made.

To run as-is (before this update) - just comment out the
#define PORTENTA_H7 // STM32H747xI
in Adafruit_Dotstar.h.
In the case of this PR - all code should run 'as-is' as long as the #define PORTENTA_H7 is commented.

Note - the associated PR is here: [https://github.com/adafruit/Adafruit_DotStar/pull/40](https://github.com/adafruit/Adafruit_DotStar/pull/40)